### PR TITLE
Separate repository implementations for alarm persistence layer

### DIFF
--- a/advanced-architecture/src/alarms/infrastructure/persistence/orm/orm-persistence.module.ts
+++ b/advanced-architecture/src/alarms/infrastructure/persistence/orm/orm-persistence.module.ts
@@ -7,6 +7,8 @@ import { UpsertMaterializedAlarmRepository } from '../../../application/ports/up
 import { AlarmItemEntity } from './entities/alarm-item-entity';
 import { AlarmEntity } from './entities/alarm.entity';
 import { OrmCreateAlarmRepository } from './repositories/create-alarm.repository';
+import { OrmFindAlarmsRepository } from './repositories/file-alarms.repository';
+import { OrmUpsertMaterializedAlarmRepository } from './repositories/upsert-materialized-alarm.repository';
 import {
   MaterializedAlarmView,
   MaterializedAlarmViewSchema,
@@ -30,11 +32,11 @@ import {
     },
     {
       provide: FindAlarmsRepository,
-      useClass: OrmCreateAlarmRepository,
+      useClass: OrmFindAlarmsRepository,
     },
     {
       provide: UpsertMaterializedAlarmRepository,
-      useClass: OrmCreateAlarmRepository,
+      useClass: OrmUpsertMaterializedAlarmRepository,
     },
   ],
   exports: [


### PR DESCRIPTION
Replace single OrmCreateAlarmRepository implementation with dedicated repository classes for each port: OrmCreateAlarmRepository, OrmFindAlarmsRepository, and OrmUpsertMaterializedAlarmRepository to properly implement the repository pattern and improve separation of concerns.